### PR TITLE
Enable setting of "passive" option on the ftp connection

### DIFF
--- a/lib/ftp_sync.rb
+++ b/lib/ftp_sync.rb
@@ -9,7 +9,7 @@ require 'fileutils'
 # newer than that timestamp, or only download files newer than their local copy.
 class FtpSync
   
-  attr_accessor :verbose, :server, :user, :password
+  attr_accessor :verbose, :server, :user, :password, :passive
   
   # Creates a new instance for accessing a ftp server 
   # requires +server+, +user+, and +password+ options
@@ -23,6 +23,7 @@ class FtpSync
     @ignore = options[:ignore]
     @recursion_level = 0
     @verbose = options[:verbose] || false
+    @passive = options[:passive] || false
   end
   
   # Recursively pull down files
@@ -167,6 +168,7 @@ class FtpSync
   private
     def connect!
       @connection = Net::FTP.new(@server)
+      @connection.passive = @passive
       @connection.login(@user, @password)
       log "Opened connection to #{@server}"
     end

--- a/test/ftp_sync_test.rb
+++ b/test/ftp_sync_test.rb
@@ -36,12 +36,25 @@ class FtpSyncTest < Test::Unit::TestCase
     assert_equal 'user', @ftp.user
     assert_equal 'pass', @ftp.password
   end
+
+  def test_can_initialize_with_params_and_options
+    assert_equal false, @ftp.passive
+    @ftp = FtpSync.new('test.server', 'user', 'pass', :passive => true)
+    assert_equal true, @ftp.passive
+  end
   
   def test_can_set_verbose
     @ftp.verbose = true
     assert_equal true, @ftp.verbose
     @ftp.verbose = false
     assert_equal false, @ftp.verbose  
+  end
+
+  def test_can_set_passive
+    @ftp.passive = true
+    assert_equal true, @ftp.passive
+    @ftp.passive = false
+    assert_equal false, @ftp.passive  
   end
   
   def test_setting_an_ignore_object    

--- a/test/net/ftp.rb
+++ b/test/net/ftp.rb
@@ -5,7 +5,7 @@ module Net
     @@listing_overrides = {}
     
     class << self
-      
+
       def ftp_src
         @ftp_src ||= File.join(Dir.tmpdir, 'munkey_ftp_src')
       end
@@ -104,6 +104,14 @@ module Net
     
     def close; end
     
+    def passive
+      @passive ||= false
+    end
+    
+    def passive=(val)
+      @passive = val
+    end
+
     private
       def src_path(p)
         File.join(self.class.ftp_src, p)


### PR DESCRIPTION
I've added an option and attribute that enables setting of the "passive" attribute on the ftp connection when it is created.
