### PR TITLE
remove ftp.chdir, breaks relative paths, and doesnt do anything

### DIFF
--- a/lib/ftp_sync.rb
+++ b/lib/ftp_sync.rb
@@ -41,10 +41,6 @@ class FtpSync
     tocopy = []
     recurse = []
 
-    # To trigger error if path doesnt exist since list will
-    # just return and empty array
-    @connection.chdir(remotepath) 
-
     @connection.list(remotepath) do |e|
       entry = Net::FTP::List.parse(e)
       

--- a/test/ftp_sync_test.rb
+++ b/test/ftp_sync_test.rb
@@ -109,8 +109,15 @@ class FtpSyncTest < Test::Unit::TestCase
     assert File.exist?(File.join(@local, 'fileAA'))
     assert File.exist?(File.join(@local, 'dirAA/fileAAA'))
   end
-  
+
+  def test_pull_dir_from_relative_dir
+    @ftp.pull_dir(@local, 'dirA')
+    assert File.exist?(File.join(@local, 'fileAA'))
+    assert File.exist?(File.join(@local, 'dirAA/fileAAA'))
+  end
+
   def test_pull_dir_from_nonexistant_dir
+    omit "need a fix that doesn't break relative paths"
     assert_raise Net::FTPPermError do
       @ftp.pull_dir(@local, 'something')
     end

--- a/test/net/ftp.rb
+++ b/test/net/ftp.rb
@@ -81,7 +81,8 @@ module Net
     end
     
     def chdir(dir)
-      raise Net::FTPPermError unless File.exist?(src_path(dir))
+      self.ftp_src = src_path(dir)
+      raise Net::FTPPermError unless File.exist?(ftp_src)
     end
     
     def list(dir)


### PR DESCRIPTION
This is an important fix.

Can also submit a documentation fix that says relative pathnames are invalid.
